### PR TITLE
Update readme for type information pop-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Sample setting:
 ```
 
 
-## LSP-related Command Line Options
+### LSP-related Command Line Options
+
 This section provides a list of the Checker Framework command line options that are related to the features of this LSP 
 plugin. You can turn on/off an option by adding/removing the corresponding flag in 
 [`commandLineOptions`](#commandlineoptions).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The list of all checkers can be found in the [Checker Framework manual](https://
 The list of command-line options that are passed to the Checker Framework. This can include options to javac.
 See the list of standard [Checker Framework options](https://checkerframework.org/manual/#checker-options). In 
 addition, a list of options that can change the behaviors of this plugin is included in 
-[LSP-related Command Line Options](#lsp-related-command-line-options).
+[LSP-related Command-Line Options](#lsp-related-command-line-options).
 
 Sample setting:
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Sample setting:
 ```
 
 
-## LSP-related Command Line Options
+## LSP-related Command-Line Options
 
-This section provides a list of the Checker Framework command line options that are related to the features of this LSP 
+This section provides a list of the Checker Framework command-line options that are related to the features of this LSP 
 plugin. You can turn on/off an option by adding/removing the corresponding flag in 
 [`commandLineOptions`](#commandlineoptions).
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The list of all checkers can be found in the [Checker Framework manual](https://
 #### `commandLineOptions`
 
 The list of command-line options that are passed to the Checker Framework. This can include options to javac.
-See the list of all [Checker Framework options](https://checkerframework.org/manual/#checker-options).
+See the list of standard [Checker Framework options](https://checkerframework.org/manual/#checker-options). In 
+addition, a list of options that can change the behaviors of this plugin is included in 
+[LSP-related Command Line Options](#lsp-related-command-line-options).
 
 Sample setting:
 
@@ -119,14 +121,14 @@ Sample setting:
 ```
 
 
-### LSP-related Command Line Options
+## LSP-related Command Line Options
 
 This section provides a list of the Checker Framework command line options that are related to the features of this LSP 
 plugin. You can turn on/off an option by adding/removing the corresponding flag in 
 [`commandLineOptions`](#commandlineoptions).
 
 - `-AlspTypeInfo`: Once enabled, the plugin will display a pop-up showing the related type information when hovering on 
-some meaningful syntax in the source file.
+some meaningful syntax in the source file. This option is enabled by default.
 
 
 ## Developer's Guide

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Sample setting:
 "checker-framework.languageserver_repo": "checker-framework-languageserver"
 ```
 
+
+## LSP-related Command Line Options
+This section provides a list of the Checker Framework command line options that are related to the features of this LSP 
+plugin. You can turn on/off an option by adding/removing the corresponding flag in 
+[`commandLineOptions`](#commandlineoptions).
+
+- `-AlspTypeInfo`: Once enabled, the plugin will display a pop-up showing the related type information when hovering on 
+some meaningful syntax in the source file.
+
+
 ## Developer's Guide
 
 To set up and build from the command line, perform the following steps:

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
           "items": {
             "type": "string"
           },
-          "default": [],
-          "description": "List of command line options that gets passed in to javac. See available options in: https://checkerframework.org/manual/#running"
+          "default": ["-AlspTypeInfo"],
+          "description": "List of command line options that gets passed in to javac. See available options in: https://github.com/eisopux/checker-framework-vscode#commandlineoptions"
         },
         "checker-framework.checkerframework_org": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
             "type": "string"
           },
           "default": ["-proc:only", "-AlspTypeInfo"],
-          "description": "List of command line options that gets passed in to javac. See available options in: https://github.com/eisopux/checker-framework-vscode#commandlineoptions"
+          "description": "List of command-line options to pass to javac. See available options: https://github.com/eisopux/checker-framework-vscode#commandlineoptions"
         },
         "checker-framework.checkerframework_org": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
           "items": {
             "type": "string"
           },
-          "default": ["-AlspTypeInfo"],
+          "default": ["-proc:only", "-AlspTypeInfo"],
           "description": "List of command line options that gets passed in to javac. See available options in: https://github.com/eisopux/checker-framework-vscode#commandlineoptions"
         },
         "checker-framework.checkerframework_org": {


### PR DESCRIPTION
Added a new section "LSP-related Command Line Options" in the readme file. Currently, we only have `-AlspTypeInfo` which will make the Checker Framework start reporting types of different components in the source file.