### PR TITLE
Add redirect to downloading script

### DIFF
--- a/scripts/get-downloader-release.js
+++ b/scripts/get-downloader-release.js
@@ -6,7 +6,8 @@ const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
 const JAR = "./checker-framework-languageserver-downloader.jar";
 
 function downloadFile(url, destination, callback) {
-    https.get(url, (response) => {
+    https.get(url, (response) => { 
+        // 302 is the HTTP status code for a temporary redirect. 
         if (response.statusCode === 302) {
             downloadFile(response.headers.location, destination, callback);
             return;

--- a/scripts/get-downloader-release.js
+++ b/scripts/get-downloader-release.js
@@ -1,10 +1,26 @@
 const https = require('https');
 const fs = require('fs');
-const url = require('url');
 
 const REPO = "eisopux/checker-framework-languageserver-downloader";
 const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
 const JAR = "./checker-framework-languageserver-downloader.jar";
+
+function downloadFile(url, destination, callback) {
+    https.get(url, (response) => {
+        if (response.statusCode === 302) {
+            downloadFile(response.headers.location, destination, callback);
+            return;
+        }
+        
+        const file = fs.createWriteStream(destination);
+        response.pipe(file);
+        file.on('finish', () => {
+            file.close(callback);
+        });
+    }).on('error', (error) => {
+        console.error(`Got error during file download: ${error.message}`);
+    });
+}
 
 https.get(API_URL, {
     headers: {
@@ -12,23 +28,14 @@ https.get(API_URL, {
     }
 }, (response) => {
     let data = '';
-
     response.on('data', (chunk) => {
         data += chunk;
     });
-
     response.on('end', () => {
         const jsonResponse = JSON.parse(data);
         const downloadUrl = jsonResponse.assets[0].browser_download_url;
-
-        const file = fs.createWriteStream(JAR);
-        https.get(new URL(downloadUrl), (response) => {
-            response.pipe(file);
-            file.on('finish', () => {
-                file.close(() => {
-                    console.log(`Downloaded the latest release to ${JAR}.`);
-                });
-            });
+        downloadFile(downloadUrl, JAR, () => {
+            console.log(`Downloaded the latest release to ${JAR}.`);
         });
     });
 }).on('error', (error) => {


### PR DESCRIPTION
Add `response.statusCode` is checked for the value 302, which is the HTTP status code for a temporary redirect. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302 **GitHub uses redirects for serving large files like releases.** If a redirect is detected, the function calls itself recursively with the new URL provided in the response.headers.location.

So if the server responds with a 302 status code, the function will follow the URL in the location header to download the file from the new location. This allows the script to handle redirects automatically.